### PR TITLE
Revert Get-ResourceFriendlyName to return friendly name again

### DIFF
--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -296,7 +296,7 @@ function Export-TargetResource()
     return $exportContent
 }
 
-function Get-ResourceFriendlyName()
+function Get-ResourceFriendlyName
 {
     [CmdletBinding()]
     param(
@@ -304,6 +304,9 @@ function Get-ResourceFriendlyName()
     )
 
     $tokens = $null 
+    $errors = $null
+    $schemaPath = $ModulePath.Replace(".psm1", ".schema.mof")
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($schemaPath, [ref] $tokens, [ref] $errors)
 
     for($i = 0; $i -lt $tokens.Length; $i++)
     {


### PR DESCRIPTION
At some point after the initial migration commit, the Get-ResourceFriendlyName stopped returning the friendly name. The current function does not reference the `$ModulePath` parameter. 

This PR just adds back the lines present in the `Initial Migration` commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/reversedsc/1)
<!-- Reviewable:end -->
