### PR TITLE
Update call to Get-DSCBlock

### DIFF
--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -271,10 +271,23 @@ function Export-TargetResource()
 
     Import-Module $ModulePath
     $results = Get-TargetResource @finalParams
+
+    $DSCBlockParams = @{}
+    foreach($fakeParameter in $fakeParameters.Keys)
+    {
+        if($results[$fakeParameter])
+        {
+            $DSCBlockParams.Add($fakeParameter,$results.Get_Item($fakeParameter))
+        }
+        else 
+        {
+            $DSCBlockParams.Add($fakeParameter,"")
+        }
+    }
     
     $exportContent = "        " + $friendlyName + " " + [System.Guid]::NewGuid().ToString() + "`r`n"
     $exportContent += "        {`r`n"
-    $exportContent += Get-DSCBlock -ModulePath $ModulePath -Params $results
+    $exportContent += Get-DSCBlock -ModulePath $ModulePath -Params $DSCBlockParams
     if($null -ne $DependsOnClause)
     {
         $exportContent += $DependsOnClause


### PR DESCRIPTION
The current call to `Get-DSCBlock` from `Export-TargetResource` throws null-value errors on parameters without values. Error output at end of the PR. 

This PR adds empty string values to the problem parameters, which seems to resolve the error. 

```powershell
~> $mandatoryParameters = @{DomainName="fakedomain.co.uk"; UserName="tony.lea"}
~> Export-TargetResource -ResourceName xADUser -MandatoryParameters $mandatoryParameters
You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\ReverseDSC\1.9.1.1\ReverseDSC.Core.psm1:76 char:13
+             $paramType = $Params[$_].GetType().Name
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

         92b54214-138d-4b3f-b18c-f28882ad4d43
        {
            CannotChangePassword = $False;
            HomePage = $;
            DisplayName = "Tony Lea";
            Description = "JobTitle";
            Notes = "";
            Office = "FakeOffice";
            State = "";
            Fax = "";
            JobTitle = "JobTitle";
            Country = "";
            Division = "";
            Initials = "";
            POBox = "";
            HomeDirectory = "";
            EmployeeID = "";
            LogonScript = "";
            GivenName = "Tony";
            EmployeeNumber = "";
            UserPrincipalName = "tony.lea@fakedomain.co.uk";
            ProfilePath = "";
            StreetAddress = "";
            CommonName = "Tony Lea";
            Path = "OU=Fake OU,DC=fakedomain,DC=co,DC=uk";
            HomePhone = "";
            City = "";
            Manager = "CN=Fake Manager,OU=Fake OU,DC=fakedomain,DC=co,DC=uk";
            MobilePhone = "";
            Pager = "";
            Company = "";
            Password = "";
            HomeDrive = "";
            OfficePhone = "FakePhone";
            Surname = "Lea";
            Enabled = $True;
            DomainController = "";
            PostalCode = "";
            IPPhone = "";
            EmailAddress = "tony.lea@fakedomain.co.uk";
            PasswordNeverExpires = $False;
            UserName = "tony.lea";
            DomainName = "fakedomain.co.uk";
            Ensure = "Present";
            Department = "Fake Department";
        }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/reversedsc/2)
<!-- Reviewable:end -->
