### PR TITLE
Enhanced Get-DSCBlock

### DIFF
--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -250,7 +250,7 @@ function Get-DSCBlock
     if ($DependsOnClause)
     {
         $DependsOn = Get-DSCDependsOnBlock -dependsOnItems $DependsOnClause
-        $dscBlock += "`t" * ($Indent + 1) + $_  + "DependsOn = " + $DependsOn + ";`r`n" 
+        $dscBlock += "`t" * ($Indent + 1) + "DependsOn = " + $DependsOn + ";`r`n" 
     }
     if ($AsFullConfigurationBlock)
     {

--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -348,7 +348,7 @@ function Export-TargetResource()
     $results = Get-TargetResource @finalParams
 
     $DSCBlockParams = @{}
-    foreach($fakeParameter in $fakeParameters.Keys)
+    foreach($fakeParameter in $results.Keys)
     {
         if($results[$fakeParameter])
         {


### PR DESCRIPTION
New Get-DSCBlock parameters introduced to receive output as Full DSC … … 
…Block. Will ease writing new reverse resources using this module

  - DependsOnClause
  - FriendlyBlockName
  - AsFullConfigurationBlock
  - Indent
Backward compatible if used with previous parameters only
Returns Similar result as Export-TargetResource

Also Export-TargetResource function fixed, however it can now be simply use Get-DSCBlock with its new parameters. I may work on that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/reversedsc/11)
<!-- Reviewable:end -->
