### PR TITLE
Remove Parameter type from "Value" on Add-ConfigurationDataEntry

### DIFF
--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -760,7 +760,6 @@ top of the parameter.
         $Key,
 
         [Parameter(Mandatory = $true)]
-        [System.String]
         $Value, 
 
         [Parameter()]


### PR DESCRIPTION
Remove the data type on the Parameter "Value" of the Add-ConfigurationDataEntry function to allow for other valid object types such as System.Object[].

Fixes #20 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/reversedsc/21)
<!-- Reviewable:end -->
