### PR TITLE
Added support for Hashtable[] in Get-DSCBlock

### DIFF
--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -208,7 +208,7 @@ Hashtable that contains the list of Key properties and their values.
         {
             $value = "@{"
             $hash = $NewParams.Item($_)
-            $hash.Keys | foreach-object {
+            $hash.Keys | ForEach-Object {
                 try
                 {
                     $value += $_.ToString() + " = `"" + $hash.Item($_).ToString() + "`"; "
@@ -283,6 +283,43 @@ Hashtable that contains the list of Key properties and their values.
                 $value = "@("
                 $hash | ForEach-Object {
                     $value += "`"" + $_ + "`","
+                }
+                if ($value.Length -gt 2)
+                {
+                    $value = $value.Substring(0, $value.Length - 1)
+                }
+                $value += ")"
+            }
+            elseif ($array.Length -gt 0 -and $array[0].GetType().Name -eq "Hashtable")
+            {
+                $value = "@("
+                foreach ($hashtable in $array)
+                {
+                    $value += "@{"
+                    foreach ($pair in $Hashtable.GetEnumerator())
+                    {
+                        if ($pair.Value -is [System.Array])
+                        {
+                            $str = "$($pair.Key)=@('$($pair.Value-join "', '")')"
+                        }
+                        else
+                        {
+                            if ($null -eq $pair.Value)
+                            {
+                                $str = "$($pair.Key)=`$null"
+                            }
+                            else
+                            {
+                                $str = "$($pair.Key)='$($pair.Value)'"
+                            }
+                        }
+                        $value += "$str, "
+                    }
+                    if ($value.Length -gt 2)
+                    {
+                        $value = $value.Substring(0, $value.Length - 2)
+                    }
+                    $value += "},"
                 }
                 if ($value.Length -gt 2)
                 {

--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -313,7 +313,7 @@ Hashtable that contains the list of Key properties and their values.
                                 $str = "$($pair.Key)='$($pair.Value)'"
                             }
                         }
-                        $value += "$str, "
+                        $value += "$str; "
                     }
                     if ($value.Length -gt 2)
                     {

--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -319,11 +319,7 @@ Hashtable that contains the list of Key properties and their values.
                     {
                         $value = $value.Substring(0, $value.Length - 2)
                     }
-                    $value += "},"
-                }
-                if ($value.Length -gt 2)
-                {
-                    $value = $value.Substring(0, $value.Length - 1)
+                    $value += "}"
                 }
                 $value += ")"
             }


### PR DESCRIPTION
When a parameter is an Hashtable array, Get-DSCBlock returns @(System.Collection.HashtableSystem.Collection.Hashtable) instead of the actual values.

This PR changes this behavior and outputs the actual values as string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/reversedsc/26)
<!-- Reviewable:end -->
