### PR TITLE
Re-insert comments from DSCParser in the generated DSC block

### DIFF
--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -118,7 +118,8 @@ Hashtable that contains the list of Key properties and their values.
         $Params
     )
 
-    $Sorted = $Params.GetEnumerator() | Sort-Object -Property Name
+    # Sort the params by name(key), exclude _metadata_* properties (coming from DSCParser)
+    $Sorted = $Params.GetEnumerator() | Sort-Object -Property Name | Where-Object {$_.Name -notlike '_metadata_*'}
     $NewParams = [Ordered]@{}
 
     foreach ($entry in $Sorted)
@@ -363,7 +364,14 @@ Hashtable that contains the list of Key properties and their values.
         {
             $additionalSpaces += " "
         }
-        $dscBlock += "            " + $_ + $additionalSpaces + " = " + $value + ";`r`n"
+        # Check for comment/metadata and insert it back here
+        $PropertyMetadataKeyName="_metadata_$($_)"
+        if ($Params.ContainsKey($PropertyMetadataKeyName)) {
+            $CommentValue=' '+$Params[$PropertyMetadataKeyName]
+        } Else {
+            $CommentValue=''
+        }
+        $dscBlock += "            " + $_ + $additionalSpaces + " = " + $value + ";" + $CommentValue + "`r`n"
     }
 
     return $dscBlock


### PR DESCRIPTION
When passing a DSCObject with comments (aka metadata, resulting from DSCParser `ConvertTo-DSCObject -IncludeComments $True`) to `Get-DSCObject`, the _\_metadata\__ fields are exported as DSC properties. This PR makes sure that the _\_metadata\__ fields are re-inserted as comments in the resulting DSC text.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/reversedsc/27)
<!-- Reviewable:end -->
