### PR TITLE
Update ReverseDSC.Core.psm1

### DIFF
--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -760,8 +760,9 @@ we should not have commas in between items it contains.
 
     if ($IsCIMArray)
     {
-        $DSCBlock = $DSCBlock.Replace("}`r`n,", "`}`r`n")
         $DSCBlock = $DSCBlock.Replace("},`r`n", "`}`r`n")
+        #$DSCBlock = $DSCBlock.Replace("}`r`n,", "`}`r`n")  # see bbelow
+        $DSCBlock = $DSCBlock -replace "\}`r`n\s*,", "}`r`n," # replace "}<crlf>[<whitespace>]," with "}<crlf>"
     }
     return $DSCBlock
 }


### PR DESCRIPTION
Wwhen $IsCimArray is $true, comma following CimInstances in an array should be removed. This isn't always happening (at least for me). So.
Removal of comma following a CimInstance in an array changed to replace '}<crlf>[<whitespace>],' using a regular expression with '}<crlf>'
I've had strange issues with a DSC-resource containing arrays of CimInstance where I couldn't get rid of the comma separating CimInstances in an array. The offending part was traced to Convert-DSCStringParamToVariable.
It should be noted that DSC-resource was generated without CimInstances which were added by hand as the resource in itself doesn't contain any, so the code generated by DRG may be different for resources that contain 'native' CimInstances

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/ReverseDSC/30)
<!-- Reviewable:end -->
