### PR TITLE
Remove trailing commas and semi colons between items of an array of CIM instances

### DIFF
--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -769,8 +769,12 @@ we should not have commas in between items it contains.
     if ($IsCIMArray)
     {
         $DSCBlock = $DSCBlock.Replace("},`r`n", "`}`r`n")
-        #$DSCBlock = $DSCBlock.Replace("}`r`n,", "`}`r`n")  # see bbelow
+        #$DSCBlock = $DSCBlock.Replace("}`r`n,", "`}`r`n") # see below
         $DSCBlock = $DSCBlock -replace "\}`r`n\s*,", "}`r`n," # replace "}<crlf>[<whitespace>]," with "}<crlf>"
+
+        $DSCBlock = $DSCBlock.replace("    ,`r`n", "    `r`n")
+        $DSCBlock = $DSCBlock.replace("`r`n;`r`n", "`r`n")
+        $DSCBlock = $DSCBlock.replace("`r`n,`r`n", "`r`n")
     }
     return $DSCBlock
 }

--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -770,7 +770,8 @@ we should not have commas in between items it contains.
     {
         $DSCBlock = $DSCBlock.Replace("},`r`n", "`}`r`n")
         #$DSCBlock = $DSCBlock.Replace("`r`n,`r`n", "`r`n") # see below
-        $DSCBlock = $DSCBlock -replace "`r`n\s*,`r`n", "`r`n" # replace "<crlf>[<whitespace>],<crlf>" with "<crlf>"
+        #$DSCBlock = $DSCBlock.Replace("`r`n;`r`n", "`r`n") # see below
+        $DSCBlock = $DSCBlock -replace "`r`n\s*[,;]`r`n", "`r`n" # replace "<crlf>[<whitespace>][,;]<crlf>" with "<crlf>"
     }
     return $DSCBlock
 }

--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -769,12 +769,8 @@ we should not have commas in between items it contains.
     if ($IsCIMArray)
     {
         $DSCBlock = $DSCBlock.Replace("},`r`n", "`}`r`n")
-        #$DSCBlock = $DSCBlock.Replace("}`r`n,", "`}`r`n") # see below
-        $DSCBlock = $DSCBlock -replace "\}`r`n\s*,", "}`r`n," # replace "}<crlf>[<whitespace>]," with "}<crlf>"
-
-        $DSCBlock = $DSCBlock.replace("    ,`r`n", "    `r`n")
-        $DSCBlock = $DSCBlock.replace("`r`n;`r`n", "`r`n")
-        $DSCBlock = $DSCBlock.replace("`r`n,`r`n", "`r`n")
+        #$DSCBlock = $DSCBlock.Replace("`r`n,`r`n", "`r`n") # see below
+        $DSCBlock = $DSCBlock -replace "`r`n\s*,`r`n", "`r`n" # replace "<crlf>[<whitespace>],<crlf>" with "<crlf>"
     }
     return $DSCBlock
 }


### PR DESCRIPTION
This fixes the issue https://github.com/microsoft/Microsoft365DSC/issues/3335 I reported where several DSC resources ended up with incorrectly placed commas in the blueprints.

With this fix in both PRs https://github.com/microsoft/Microsoft365DSC/pull/3362 and https://github.com/microsoft/Microsoft365DSC/pull/3364 can be cancelled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/ReverseDSC/33)
<!-- Reviewable:end -->
