### PR TITLE
Fix quotes in inner dsc block

### DIFF
--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -715,10 +715,15 @@ we should not have commas in between items it contains.
                     When the parameter is a CIM array, it may contain parameter with double quotes
                     We need to ensure that endPosition does not correspond to such parameter 
                     by checking if the second character before " is =
+                    Additionally, there might be other values in the DSC block, e.g. from xml,
+                    which contain other properties like <?xml version="1.0"?>, where we do
+                    not want to remove the quotes as well.
                 #>
                 if ($IsCIMArray)
                 {
-                    while ($endPosition -gt 1 -and $DSCBlock.substring($endPosition -2,3) -eq "= `"")
+                    while ($endPosition -gt 1 -and `
+                        ($DSCBlock.substring($endPosition -2,3) -eq "= `"" -or `
+                         $DSCBlock.substring($endPosition -1,2) -eq "=`""))
                     {
                         #This retrieve the endquote that we skip
                         $endPosition = $DSCBlock.IndexOf("`"", $endPosition + 1)
@@ -789,10 +794,15 @@ we should not have commas in between items it contains.
             When the parameter is a CIM array, it may contain parameter with double quotes
             We need to ensure that startPosition does not correspond to such parameter 
             by checking if the second character before " is =
+            Additionally, there might be other values in the DSC block, e.g. from xml,
+            which contain other properties like <?xml version="1.0"?>, where we do
+            not want to remove the quotes as well.
         #>
         if ($IsCIMArray)
         {
-            while ($startPosition -gt 1 -and $DSCBlock.Substring($startPosition -2,3) -eq "= `"")
+            while ($startPosition -gt 1 -and `
+                ($DSCBlock.Substring($startPosition -2,3) -eq "= `"" -or `
+                 $DSCBlock.Substring($startPosition -1,2) -eq "=`""))
             {
                 #This retrieve the endquote that we skip
                 $startPosition = $DSCBlock.IndexOf("`"", $startPosition + 1)


### PR DESCRIPTION
@NikCharlebois

This pull request fixes an issue where in the inner DSC block (specified by `ParameterName`) were quotes for value specification, e.g. from XML. If quotes were present inside the block, they were removed as well, and not only the "surrounding" quotes necessary for the DSC block to create. 

Example input:
```
IntuneDeviceConfigurationCustomPolicyWindows10 "IntuneDeviceConfigurationCustomPolicyWindows10-Intune-P-WinAll-ConfProf-Cust-Collaboration-Surface-Hub"
{
    ApplicationId         = `$ConfigurationData.NonNodeData.ApplicationId;
    OmaSettings           = @("
        MSFT_MicrosoftGraphomaSetting{
            Description = 'LAN Profile'
            FileName = 'Lan_Setting_SurfaceHub.xml'
            OmaUri = './Vendor/MSFT/SurfaceHub/Dot3/LanProfile'
            Value = '<?xml version="1.0"?>
<LANProfile xmlns="http://www.microsoft.com/networking/LAN/profile/v1">
    <MSM>
        <security>
            <OneXEnforced>false</OneXEnforced>
            <OneXEnabled>true</OneXEnabled>
            <OneX xmlns="http://www.microsoft.com/networking/OneX/v1">
                <maxAuthFailures>1</maxAuthFailures>
                <authMode>machine</authMode>
                <EAPConfig><EapHostConfig xmlns="http://www.microsoft.com/provisioning/EapHostConfig"><EapMethod><Type xmlns="http://www.microsoft.com/provisioning/EapCommon">13</Type><VendorId xmlns="http://www.microsoft.com/provisioning/EapCommon">0</VendorId><VendorType
xmlns="http://www.microsoft.com/provisioning/EapCommon">0</VendorType><AuthorId xmlns="http://www.microsoft.com/provisioning/EapCommon">0</AuthorId></EapMethod><Config xmlns="http://www.microsoft.com/provisioning/EapHostConfig"><Eap
xmlns="http://www.microsoft.com/provisioning/BaseEapConnectionPropertiesV1"><Type>13</Type><EapType
xmlns="http://www.microsoft.com/provisioning/EapTlsConnectionPropertiesV1"><CredentialsSource><CertificateStore><SimpleCertSelection>true</SimpleCertSelection></CertificateStore></CredentialsSource><ServerValidation><DisableUserPromptForServerValidation>false</DisableUserPromptF
orServerValidation><ServerNames></ServerNames></ServerValidation><DifferentUsername>false</DifferentUsername><PerformServerValidation xmlns="http://www.microsoft.com/provisioning/EapTlsConnectionPropertiesV2">true</PerformServerValidation><AcceptServerName
xmlns="http://www.microsoft.com/provisioning/EapTlsConnectionPropertiesV2">false</AcceptServerName></EapType></Eap></Config></EapHostConfig></EAPConfig>
            </OneX>
        </security>
    </MSM>
</LANProfile>
'
            odataType = '#microsoft.graph.omaSettingStringXml'
            IsEncrypted = `$False
            DisplayName = 'LAN Profile'
        }
    ");
    SupportsScopeTags     = `$True;
    TenantId              = `$OrganizationName;
}
```

This resulted in the following output for the `Value` property. See the missing quotes, e.g. after `xmlns=http` instead of `xmlns="http..."`:

```
<?xml version=1.0?>
<LANProfile xmlns=http://www.microsoft.com/networking/LAN/profile/v1>
    <MSM>
        <security>
            <OneXEnforced>false</OneXEnforced>
            <OneXEnabled>true</OneXEnabled>
            <OneX xmlns=http://www.microsoft.com/networking/OneX/v1>
                <maxAuthFailures>1</maxAuthFailures>
                <authMode>machine</authMode>
                <EAPConfig><EapHostConfig xmlns=http://www.microsoft.com/provisioning/EapHostConfig><EapMethod><Type xmlns=http://www.microsoft.com/provisioning/EapCommon>13</Type><VendorId xmlns=http://www.microsoft.com/provisioning/EapCommon>0</VendorId><VendorType
xmlns=http://www.microsoft.com/provisioning/EapCommon>0</VendorType><AuthorId xmlns=http://www.microsoft.com/provisioning/EapCommon>0</AuthorId></EapMethod><Config xmlns=http://www.microsoft.com/provisioning/EapHostConfig><Eap
xmlns=http://www.microsoft.com/provisioning/BaseEapConnectionPropertiesV1><Type>13</Type><EapType
xmlns=http://www.microsoft.com/provisioning/EapTlsConnectionPropertiesV1><CredentialsSource><CertificateStore><SimpleCertSelection>true</SimpleCertSelection></CertificateStore></CredentialsSource><ServerValidation><DisableUserPromptForServerValidation>false</DisableUserPromptF
orServerValidation><ServerNames></ServerNames></ServerValidation><DifferentUsername>false</DifferentUsername><PerformServerValidation xmlns=http://www.microsoft.com/provisioning/EapTlsConnectionPropertiesV2>true</PerformServerValidation><AcceptServerName
xmlns=http://www.microsoft.com/provisioning/EapTlsConnectionPropertiesV2>false</AcceptServerName></EapType></Eap></Config></EapHostConfig></EAPConfig>
            </OneX>
        </security>
    </MSM>
</LANProfile>
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/ReverseDSC/36)
<!-- Reviewable:end -->
