### PR TITLE
Fix escaping of the escape quotes in Strings

### DIFF
--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -162,7 +162,7 @@ Hashtable that contains the list of Key properties and their values.
         {
             if (!$null -eq $NewParams.Item($_))
             {
-                $value = "`"" + $NewParams.Item($_).ToString().Replace("`"", "```"") + "`""
+                $value = "`"" + $NewParams.Item($_).ToString().Replace('`', '``').Replace("`"", "```"") + "`""
             }
             else
             {


### PR DESCRIPTION
@NikCharlebois
This PR fixes the escaping of escape quotes in Strings. Example: 

Currently, ```"<table border=0 cellspacing=0 cellpadding=0 align=left width=`"100%`">"``` would be escaped to `"<table border=0 cellspacing=0 cellpadding=0 align=left width=``"100%``">"`, which is invalid because the escape quotes for the " double quotes are not escaped themselves, leading to a parse error within PowerShell. 

The implemented solution is to first escape the escape quotes within the strings and then escape the standard double quotes. New result: `"<table border=0 cellspacing=0 cellpadding=0 align=left width=```"100%```">"`, which is valid PowerShell.

- Fixes https://github.com/microsoft/Microsoft365DSC/issues/5135

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/ReverseDSC/37)
<!-- Reviewable:end -->
