### PR TITLE
Fix " and ` escaping on string arrays

### DIFF
--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -283,7 +283,7 @@ Hashtable that contains the list of Key properties and their values.
             {
                 $value = "@("
                 $hash | ForEach-Object {
-                    $value += "`"" + $_ + "`","
+                    $value += "`"" + $_.ToString().Replace('`', '``').Replace("`"", "```"") + "`","
                 }
                 if ($value.Length -gt 2)
                 {


### PR DESCRIPTION
Strings escape both " and ` correctly, but if inside string arrays this doesn't happen, this PR applies the same logic to string arrays to fix the issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/ReverseDSC/38)
<!-- Reviewable:end -->
