### PR TITLE
Allow variables in strings

### DIFF
--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -118,7 +118,11 @@ function Get-DSCBlock
 
         [Parameter()]
         [System.String[]]
-        $NoEscape
+        $NoEscape,
+
+        [Parameter()]
+        [switch]
+        $AllowVariablesInStrings
     )
 
     # Sort the params by name(key), exclude _metadata_* properties (coming from DSCParser)
@@ -171,7 +175,14 @@ function Get-DSCBlock
                 }
                 else
                 {
-                    $value = "`"" + $NewParams.Item($_).ToString().Replace('`', '``').Replace('$', '`$').Replace("`"", "```"") + "`""
+                    if ($AllowVariablesInStrings)
+                    {
+                        $value = "`"" + $NewParams.Item($_).ToString().Replace('`', '``').Replace("`"", "```"") + "`""
+                    }
+                    else
+                    {
+                        $value = "`"" + $NewParams.Item($_).ToString().Replace('`', '``').Replace('$', '`$').Replace("`"", "```"") + "`""
+                    }
                 }
             }
             else
@@ -300,7 +311,14 @@ function Get-DSCBlock
                     }
                     else
                     {
-                        $value += "`"" + $_.ToString().Replace('`', '``').Replace('$', '`$').Replace("`"", "```"") + "`","
+                        if ($AllowVariablesInStrings)
+                        {
+                            $value += "`"" + $_.ToString().Replace('`', '``').Replace("`"", "```"") + "`","
+                        }
+                        else
+                        {
+                            $value += "`"" + $_.ToString().Replace('`', '``').Replace('$', '`$').Replace("`"", "```"") + "`","
+                        }
                     }
                 }
                 # Remove trailing comma if it exists


### PR DESCRIPTION
Based on the feedback of @ricmestre in #44, there is now the option to skip the `$` dollar sign replacement in Strings and CIM Instances. The default behavior is to replace them all, but using the new switch parameter `-AllowVariablesInStrings`, the behavior without escaping dollar signs just as it was before 2.0.0.25 can be restored. 

Fixes #44