### PR TITLE
Fix Integer types not matching

### DIFF
--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -313,7 +313,7 @@ function Get-DSCBlock
                 }
             }
         }
-        elseif ($paramType -eq "System.UInt32[]")
+        elseif ($paramType -match "Int.*\[\]")
         {
             $hash = $NewParams.Item($_)
             if ($hash)


### PR DESCRIPTION
This PR fixes an issue where normal integer types (e.g. `System.Int32`, `System.Int16` etc.) were not caught in the `Get-DSCBlock` function. Instead, they were treated as objects, resulting in an invalid block. 

```powershell
# Before
@{
    PrintingSettings = @(01)
}

# After
@{
    PrintingSettings = @(0,1)
}
```