### PR TITLE
Allow update of values in configuration document

### DIFF
--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -967,15 +967,14 @@ top of the parameter.
         [System.String]
         $Description
     )
+
     if ($null -eq $ConfigurationDataContent[$Node])
     {
         $ConfigurationDataContent.Add($Node, @{})
         $ConfigurationDataContent[$Node].Add("Entries", @{})
     }
-    if (-not $ConfigurationDataContent[$Node].Entries.ContainsKey($Key))
-    {
-        $ConfigurationDataContent[$Node].Entries.Add($Key, @{Value = $Value; Description = $Description })
-    }
+
+    $ConfigurationDataContent[$Node].Entries[$Key] = @{ Value = $Value; Description = $Description }
 }
 
 function Get-ConfigurationDataEntry

--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -971,7 +971,7 @@ top of the parameter.
     if ($null -eq $ConfigurationDataContent[$Node])
     {
         $ConfigurationDataContent.Add($Node, @{})
-        $ConfigurationDataContent[$Node].Add("Entries", @{})
+        $ConfigurationDataContent[$Node].Add("Entries", [ordered]@{})
     }
 
     $ConfigurationDataContent[$Node].Entries[$Key] = @{ Value = $Value; Description = $Description }

--- a/ReverseDSC.Core.psm1
+++ b/ReverseDSC.Core.psm1
@@ -1054,7 +1054,7 @@ hashtable for the ConfigurationData content as a formatted string.
         $psd1Content += "            PSDscAllowDomainUser        = `$true;`r`n"
         $psd1Content += "            #region Parameters`r`n"
         $keyValuePair = $ConfigurationDataContent[$node].Entries
-        foreach ($key in $keyValuePair.Keys)
+        foreach ($key in $keyValuePair.Keys | Sort-Object)
         {
             if ($null -ne $keyValuePair[$key].Description)
             {
@@ -1088,7 +1088,7 @@ hashtable for the ConfigurationData content as a formatted string.
     {
         $psd1Content += "        @{`r`n"
         $keyValuePair = $ConfigurationDataContent[$node].Entries
-        foreach ($key in $keyValuePair.Keys)
+        foreach ($key in $keyValuePair.Keys | Sort-Object)
         {
             try
             {


### PR DESCRIPTION
This PR changes the assignment of values to a configuration document to allow updates to it and not only assign new values to it. The consequence is that multiple runs of `Export-M365DSCConfiguration` now update the `ConfigurationData.psd1` appropriately if the authentication methods change during the different runs.

- Fixes #46